### PR TITLE
Adding import for 'func_timeout'

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -14,7 +14,8 @@ setup(
           'scikit-learn',
           'scipy',
           'tqdm',
-          'matplotlib'
+          'matplotlib',
+          'func-timeout'
       ],
   classifiers=[
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Dear maintainer, 

I am adding the following dependency which I think is missing: https://pypi.org/project/func-timeout/

Otherwise when importing the package `import lcdb` it results in a `ModuleNotFoundError`.

After installing `func-timeout` the error disappeared for me. If you merged this change you will need to release a new version of the package on PyPI.

Best regards,
Romain.