### PR TITLE
correct func_timeout dependency and add openml dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -15,7 +15,8 @@ setup(
           'scipy',
           'tqdm',
           'matplotlib',
-          'func-timeout'
+          'func_timeout',
+          'openml'
       ],
   classifiers=[
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This pull request addresses issue #14 by replacing the incorrectly-spelled `func-timeout` to `func_timeout` and adding the `openml` dependency. To test that it works, I would suggest creating a fresh virtual environment, opening the project in that environment and running `pip install .` in the same directory where `setup.py` is located in. If this fix is successful, there should be no errors