### PR TITLE
added support for regularizers:

### DIFF
--- a/publications/2023-neurips/install/requirements.txt
+++ b/publications/2023-neurips/install/requirements.txt
@@ -2,3 +2,4 @@ numpy
 openml
 py_experimenter
 tqdm
+keras-swa

--- a/publications/2023-neurips/install/requirements.txt
+++ b/publications/2023-neurips/install/requirements.txt
@@ -2,4 +2,3 @@ numpy
 openml
 py_experimenter
 tqdm
-keras-swa

--- a/publications/2023-neurips/lcdb/data/_base.py
+++ b/publications/2023-neurips/lcdb/data/_base.py
@@ -29,10 +29,6 @@ def load_task(task_name: str):
     if metadata["type"] == "classification":
         assert "num_classes" in metadata
 
-        X, y = data
-        y = LabelEncoder().fit_transform(y)
-        data = (X, y)
-
     return data, metadata
 
 

--- a/publications/2023-neurips/lcdb/data/_openml.py
+++ b/publications/2023-neurips/lcdb/data/_openml.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import numpy as np
 import openml
+import pandas as pd
 
 
 def load_from_openml(dataset_id: str) -> Tuple[np.ndarray, np.ndarray, dict]:
@@ -27,6 +28,8 @@ def load_from_openml(dataset_id: str) -> Tuple[np.ndarray, np.ndarray, dict]:
         target=dataset.default_target_attribute
     )
     X, y = X.values, y.values
+    if isinstance(y, pd.core.arrays.categorical.Categorical):
+        y = np.array([v for v in y])
 
     metadata = {
         "type": "classification",

--- a/publications/2023-neurips/lcdb/scorer.py
+++ b/publications/2023-neurips/lcdb/scorer.py
@@ -1,9 +1,9 @@
-import itertools as it
+from itertools import combinations, product
 
 import numpy as np
 from lcdb.timer import Timer
+
 from sklearn.metrics import (
-    accuracy_score,
     brier_score_loss,
     confusion_matrix,
     log_loss,
@@ -14,35 +14,38 @@ from sklearn.metrics import (
 
 
 class ClassificationScorer:
-    def __init__(self, classes: list, timer: Timer = None) -> None:
-        if not isinstance(classes, list):
-            raise ValueError(f"'classes'] must be a list but is {type(classes)}")
-        self.classes = classes
+    def __init__(self, classes_learner: list, classes_overall: list, timer: Timer = None) -> None:
+        if not isinstance(classes_learner, list):
+            raise ValueError(f"'classes_learner' must be a list but is {type(classes_learner)}")
+        if not isinstance(classes_overall, list):
+            raise ValueError(f"'classes_overall' must be a list but is {type(classes_overall)}")
+        self.classes_learner = classes_learner
+        self.classes_overall = classes_overall
+        self.padded_classes = sorted(set(classes_overall) - set(classes_learner))
+        if len(self.padded_classes) > 0:
+            label_order_after_expansion = self.classes_learner + self.padded_classes
+            self.reordering_index = [label_order_after_expansion.index(label) for label in self.classes_overall]
+        else:
+            self.reordering_index = None
         self.timer = Timer() if timer is None else timer
 
     def score(self, y_true, y_pred, y_pred_proba):
-        relevant_labels = self.classes.copy()
 
-        labels_in_true_data_not_used_by_workflow = list(
-            set(y_true).difference(relevant_labels)
-        )
-
-        if len(labels_in_true_data_not_used_by_workflow) > 0:
+        # make sure that y_predict_proba is a matrix over all known labels (not only the ones known to the learner)
+        if len(self.padded_classes) > 0:
             expansion_matrix = np.zeros(
-                (len(y_true), len(labels_in_true_data_not_used_by_workflow))
+                (len(y_true), len(self.padded_classes))
             )
-            relevant_labels.extend(labels_in_true_data_not_used_by_workflow)
             y_pred_proba = np.concatenate([y_pred_proba, expansion_matrix], axis=1)
-            sorted_idx = np.argsort(relevant_labels)
-            relevant_labels = np.array(relevant_labels)[sorted_idx]
-            y_pred_proba = y_pred_proba[:, sorted_idx]
+            y_pred_proba = y_pred_proba[:, self.reordering_index]
 
-        is_binary = len(np.unique(y_true)) == 2
+        labels_in_ground_truth = sorted(np.unique(y_true))
+        num_labels_in_ground_truth = len(labels_in_ground_truth)
+        is_unary = num_labels_in_ground_truth == 1
+        is_binary = num_labels_in_ground_truth == 2
 
         metric_names = [
             "confusion_matrix",
-            # TODO: Removed because redundant with confusion_matrix
-            # "accuracy",
             "auc",
             "log_loss",
             "brier_score",
@@ -56,54 +59,82 @@ class ClassificationScorer:
 
                 if metric_name == "confusion_matrix":
                     score = np.round(
-                        confusion_matrix(y_true, y_pred, labels=relevant_labels), 5
+                        confusion_matrix(y_true, y_pred, labels=self.classes_overall), 5
                     ).tolist()
 
-                elif metric_name == "accuracy":
-                    # TODO: why not balanced accuracy?
-                    score = np.round(accuracy_score(y_true, y_pred), 5)
                 elif metric_name == "auc":
-                    if is_binary:
+                    if is_unary:
+                        score = np.nan  # AUC not defined for single class problems
+                    elif is_binary:
                         score = np.round(
                             roc_auc_score(
-                                y_true, y_pred_proba[:, 1], labels=relevant_labels
+                                y_true, y_pred_proba[:, 1], labels=self.classes_overall
                             ),
                             5,
                         )
                     else:
+
+                        # if the learner has a superset of the ground truth labels, only use the ground truth labels
+                        if set(y_true).issubset(set(self.classes_learner)):
+                            accepted_labels = labels_in_ground_truth
+
+                        # otherwise use all the labels that are either present in ground truth or in the predictions
+                        else:
+                            accepted_labels = [
+                                l for i, l in enumerate(self.classes_overall)
+                                if (
+                                    l in y_true or
+                                    y_pred_proba[:, i].sum() > 0
+                                )
+                            ]
+
+                        # generate a proper distribution over the remaining labels
+                        mask_labels_auc = np.isin(self.classes_overall, accepted_labels)
+                        y_pred_proba_auc = y_pred_proba[:, mask_labels_auc]
+                        if num_labels_in_ground_truth != len(self.classes_learner):
+                            y_pred_proba_auc /= y_pred_proba_auc.sum(axis=1, keepdims=1)
+
+                        # compute the different AUC scores
                         score = {}
-                        for multi_class, average in it.product(
+                        for multi_class, average in product(
                             ["ovr", "ovo"], ["micro", "macro", "weighted", None]
                         ):
                             if average in [None, "micro"] and multi_class != "ovr":
                                 continue
-                            auc = np.round(
-                                roc_auc_score(
-                                    y_true=y_true,
-                                    y_score=y_pred_proba,
-                                    labels=relevant_labels,
-                                    multi_class=multi_class,
-                                    average=average,
-                                ),
-                                5,
-                            )
+                            try:
+                                auc = np.round(
+                                    roc_auc_score(
+                                        y_true=y_true,
+                                        y_score=y_pred_proba_auc,
+                                        labels=accepted_labels,
+                                        multi_class=multi_class,
+                                        average=average,
+                                    ),
+                                    5,
+                                )
+                            except ValueError as e:
+                                if "Only one class present in y_true." in str(e):
+                                    auc = np.nan
+                                else:
+                                    raise e
+
                             score[f"auc_{multi_class}_{average}"] = auc
                 elif metric_name == "log_loss":
                     y_base = y_pred_proba[:, 1] if is_binary else y_pred_proba
                     score = np.round(
-                        log_loss(y_true, y_base, labels=relevant_labels), 5
+                        log_loss(y_true, y_base, labels=self.classes_overall), 5
                     )
                 elif metric_name == "brier_score":
                     if is_binary:
                         score = np.round(
                             brier_score_loss(
-                                y_true, y_pred_proba[:, 1], pos_label=relevant_labels[1]
+                                y_true, y_pred_proba[:, 1], pos_label=self.classes_overall[1]
                             ),
                             5,
                         )
                     else:
-                        y_true_binarized = np.zeros((len(y_true), len(relevant_labels)))
-                        for j, label in enumerate(relevant_labels):
+                        y_true_binarized = np.zeros((len(y_true), len(self.classes_overall)))
+                        for j, label in enumerate(self.classes_overall):
                             mask = y_true == label
                             y_true_binarized[mask, j] = 1
                         score = np.round(
@@ -114,7 +145,6 @@ class ClassificationScorer:
                 metric_timer["value"] = score
 
                 scores[metric_name] = score
-
         return scores
 
 

--- a/publications/2023-neurips/lcdb/workflow/keras/_augmentation.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_augmentation.py
@@ -1,0 +1,55 @@
+from tensorflow import data as tf_data
+from keras.random import gamma as tf_random_gamma
+import keras.ops as ops
+
+
+def sample_beta_distribution(size, concentration_0=0.2, concentration_1=0.2):
+    gamma_1_sample = tf_random_gamma(shape=[size], alpha=concentration_1)
+    gamma_2_sample = tf_random_gamma(shape=[size], alpha=concentration_0)
+    return gamma_1_sample / (gamma_1_sample + gamma_2_sample)
+
+
+def mix_up(ds_one, ds_two, alpha=0.2):
+    # Unpack two datasets
+    X_1, y_1 = ds_one
+    X_2, y_2 = ds_two
+    batch_size = X_1.shape[0]
+
+    print(X_1.shape)
+
+    # Sample lambda and reshape it to do the mixup
+    l = sample_beta_distribution(batch_size, alpha, alpha)
+    #x_l = ops.reshape(l, X_1.shape)
+    #y_l = ops.reshape(l, y_1.shape)
+    print(l)
+    #print(x_l)
+    #print(y_l)
+
+    # Perform mixup on both images and labels by combining a pair of images/labels
+    # (one from each dataset) into one image/label
+    X = X_1 * x_l + X_2 * (1 - x_l)
+    y = y_1 * y_l + y_2 * (1 - y_l)
+    return X, y
+
+
+def augment_with_mixup(X, y):
+
+    print(X.shape)
+
+    # get two randomly shuffled version of the datasets and zip them
+    train_ds_one = (
+        tf_data.Dataset.from_tensor_slices((X, y))
+        .shuffle(X.shape[0])
+    )
+    train_ds_two = (
+        tf_data.Dataset.from_tensor_slices((X, y))
+        .shuffle(X.shape[0])
+    )
+    train_ds = tf_data.Dataset.zip((train_ds_one, train_ds_two))
+
+    # now mix-up pair instances
+    train_ds_mu = train_ds.map(
+        lambda ds_one, ds_two: mix_up(ds_one, ds_two, alpha=0.2)
+        #num_parallel_calls=AUTO,
+    )
+    return train_ds_mu

--- a/publications/2023-neurips/lcdb/workflow/keras/_dense.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_dense.py
@@ -72,7 +72,10 @@ CONFIG_SPACE = ConfigurationSpace(
         "snapshot_ensembles": Categorical(
             "snapshot_ensembles", items=[False, True], default=True
         ),
-        # TODO: Define Conditional for this one and also the period for Snapshot Ensembles
+        # TODO: The following snapshot parameters should be made conditional and only appear if snapshot_ensembles=True
+        "snapshot_ensembles_period": Integer(
+            "snapshot_ensembles_period", bounds=[2, 100], default=20
+        ),
         "snapshot_ensembles_reset_weights": Categorical(
             "snapshot_ensembles_reset_weights", items=[False, True], default=False
         ),
@@ -183,6 +186,7 @@ class DenseNNWorkflow(BaseWorkflow):
         stochastic_weight_averaging=True,
         lookahead=True,
         snapshot_ensembles=True,
+        snapshot_ensembles_period=20,
         snapshot_ensembles_reset_weights=False,
         shuffle_each_epoch=True,
         transform_real="none",
@@ -242,6 +246,7 @@ class DenseNNWorkflow(BaseWorkflow):
         self.stochastic_weight_averaging = stochastic_weight_averaging
         self.lookahead = lookahead
         self.snapshot_ensembles = snapshot_ensembles
+        self.snapshot_ensembles_period = snapshot_ensembles_period
         self.snapshot_ensembles_reset_weights = snapshot_ensembles_reset_weights
         self.snapshot_callback = None
 
@@ -410,7 +415,7 @@ class DenseNNWorkflow(BaseWorkflow):
                 workflow=self,
                 optimizer=base_optimizer,
                 reset_weights=self.snapshot_ensembles_reset_weights,
-                period=50
+                period=self.snapshot_ensembles_period
             )
             callbacks.append(self.snapshot_callback)
 

--- a/publications/2023-neurips/lcdb/workflow/keras/_lookahead.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_lookahead.py
@@ -1,11 +1,7 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import tensorflow as tf
-from tensorflow.python.eager import context
 import keras.ops as ops
 from keras.optimizers import Optimizer
+from keras.src.backend import convert_to_numpy
+from .utils import serialize_object, deserialize_object
 
 
 class Lookahead(Optimizer):
@@ -14,12 +10,26 @@ class Lookahead(Optimizer):
     Lookahead Optimizer: https://arxiv.org/abs/1907.08610
     '''
 
-    def __init__(self, optimizer, la_steps=5, la_alpha=0.8, name="Lookahead"):
+    def __init__(self,
+                 optimizer,
+                 learning_rate=0.8,
+                 la_steps=5,
+                 weight_decay=None,
+                 clipnorm=None,
+                 global_clipnorm=None,
+                 clipvalue=None,
+                 use_ema= False,
+                 ema_momentum= 0.99,
+                 ema_overwrite_frequency=None,
+                 loss_scale_factor= None,
+                 gradient_accumulation_steps= None,
+                 name="Lookahead"
+                 ):
         """optimizer: inner optimizer
         la_steps (int): number of lookahead steps
         la_alpha (float): linear interpolation factor. 1.0 recovers the inner optimizer.
         """
-        super().__init__(learning_rate=la_alpha, name=name)
+        super().__init__(learning_rate=learning_rate, name=name)
         self.optimizer = optimizer
         self._total_la_steps = la_steps
         self.phis = None
@@ -31,11 +41,11 @@ class Lookahead(Optimizer):
         # Create slots for the cached parameters.
         self.phis = []
         for variable in variables:
-            self.phis.append(
-                self.add_variable_from_reference(
-                    reference_variable=variable, name="phi"
-                )
+            phi = self.add_variable_from_reference(
+                reference_variable=variable, name="phi"
             )
+            self.assign(phi, variable)
+            self.phis.append(phi)
 
     def update_step(self, gradient, variable, learning_rate):
 
@@ -43,7 +53,7 @@ class Lookahead(Optimizer):
         self.optimizer.update_step(gradient, variable, self.optimizer.learning_rate)
 
         # create condition to check whether this iteration is one in which the outer loop logic should be executed
-        local_step = ops.cast(self.iterations + 1, tf.dtypes.int64)
+        local_step = self.iterations + 1
         sync_cond = ops.equal(
             ops.floor_divide(local_step, self._total_la_steps) * self._total_la_steps,
             local_step
@@ -52,16 +62,29 @@ class Lookahead(Optimizer):
         # define the step-back logic and apply it conditionally
         phi = self.phis[self._get_variable_index(variable)]
         step_back = phi + learning_rate * (variable - phi)  # the learning rate here is the one of Lookahead
-        with tf.control_dependencies([step_back]):
 
-            # update phi values (cache values) if this iteration include the outer loop
-            self.assign(
-                phi,
-                tf.where(sync_cond, step_back, phi)
-            )
+        # update phi values (cache values) if this iteration include the outer loop
+        self.assign(
+            phi,
+            ops.where(sync_cond, step_back, phi)
+        )
 
-            # in that case, also over-write the actual parameter values by that same values
-            self.assign(
-                variable,
-                tf.where(sync_cond, step_back, variable)
-            )
+        # in that case, also over-write the actual parameter values by that same values
+        self.assign(
+            variable,
+            ops.where(sync_cond, step_back, variable)
+        )
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "optimizer": serialize_object(self.optimizer),
+            "learning_rate": convert_to_numpy(self.learning_rate),
+            "la_steps": self._total_la_steps
+        })
+        return config
+
+    @classmethod
+    def from_config(cls, config, custom_objects=None):
+        config["optimizer"] = deserialize_object(config["optimizer"])
+        return cls(**config)

--- a/publications/2023-neurips/lcdb/workflow/keras/_shake.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_shake.py
@@ -1,0 +1,35 @@
+from keras import backend as K
+from keras.layers import Layer
+
+
+class ShakeShake(Layer):
+    """ Shake-Shake-Image Layer """
+
+    def __init__(self, **kwargs):
+        super(ShakeShake, self).__init__(**kwargs)
+
+    def build(self, input_shape):
+        super(ShakeShake, self).build(input_shape)
+
+    def call(self, x):
+
+        # unpack x1 and x2
+        assert isinstance(x, list)
+        x1, x2 = x
+        # create alpha and beta
+        batch_size = K.shape(x1)[0]
+        alpha = K.random_uniform((batch_size, 1, 1, 1))
+        beta = K.random_uniform((batch_size, 1, 1, 1))
+
+        # shake-shake during training phase
+        def x_shake():
+            return beta * x1 + (1 - beta) * x2 + K.stop_gradient((alpha - beta) * x1 + (beta - alpha) * x2)
+        # even-even during testing phase
+
+        def x_even():
+            return 0.5 * x1 + 0.5 * x2
+        return K.in_train_phase(x_shake, x_even)
+
+    def compute_output_shape(self, input_shape):
+        assert isinstance(input_shape, list)
+        return input_shape[0]

--- a/publications/2023-neurips/lcdb/workflow/keras/_snapshot.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_snapshot.py
@@ -1,0 +1,96 @@
+import math
+import os
+
+from keras.callbacks import Callback
+from keras.src.backend import convert_to_numpy
+from keras.models import clone_model
+
+import numpy as np
+
+
+class Snapshot(Callback):
+
+    def __init__(
+            self,
+            workflow,
+            optimizer,
+            period=20,
+            reset_weights=False,
+            verbose=0
+    ):
+
+        super(Snapshot, self).__init__()
+        self.workflow = workflow
+        self.optimizer = optimizer
+        self.verbose = verbose
+        self.period = period
+        self.reset_weights = reset_weights
+
+        self.checkpoint_models = []
+
+    def _set_lr(self, lr):
+        self.model.optimizer.learning_rate = lr
+
+    def _get_lr(self):
+        return float(convert_to_numpy(self.model.optimizer.learning_rate))
+
+    def _reset_weights(self):
+
+        # Reset weights randomly using their own initializers
+        for layer in self.model.layers:
+            seed = np.random.randint(0, 10000)
+            if hasattr(layer, 'kernel_initializer'):
+                if hasattr(layer.kernel_initializer, "seed"):
+                    layer.kernel_initializer.seed = seed
+                new_kernel = layer.kernel_initializer(shape=layer.kernel.shape)
+                if hasattr(layer, 'bias_initializer') and layer.use_bias:
+                    if hasattr(layer.bias_initializer, "seed"):
+                        layer.bias_initializer.seed = seed
+                    new_bias = layer.bias_initializer(shape=layer.bias.shape)
+                    layer.set_weights([new_kernel, new_bias])
+                else:
+                    layer.set_weights([new_kernel])
+
+    def on_epoch_end(self, epoch, logs=None):
+
+        # only do something at the end of each cycle
+        if epoch == 0 or (epoch + 1) % self.period != 0:
+            return
+
+        # save model for this cycle
+        model_copy = clone_model(self.model)
+        model_copy.set_weights(self.model.get_weights())
+        self.checkpoint_models.append(model_copy)
+
+        # Resetting the weights if configured (the LR is implicitly reset at the beginning of the next epoch)
+        if self.reset_weights:
+            self._reset_weights()
+
+    def on_epoch_begin(self, epoch, logs=None):
+
+        # adjust learning rate through cyclic cosine annealing
+        if epoch > 0:
+            lr = math.pi * (epoch % self.period) / self.period
+            lr = self.base_lr / 2 * (math.cos(lr) + 1)
+            self._set_lr(lr)
+            print(f"Learning rate is now {convert_to_numpy(self.model.optimizer.learning_rate)}")
+
+    def on_test_begin(self, logs=None):
+        self.workflow.use_snapshot_models_for_prediction = True
+
+    def on_test_end(self, logs=None):
+        self.workflow.use_snapshot_models_for_prediction = False
+
+    def on_predict_begin(self, logs=None):
+        self.workflow.use_snapshot_models_for_prediction = True
+
+    def on_predict_end(self, logs=None):
+        self.workflow.use_snapshot_models_for_prediction = False
+
+    def set_model(self, model):
+        super().set_model(model)
+
+        # Get initial learning rate
+        self.base_lr = float(self._get_lr())
+
+        self._reset_weights()

--- a/publications/2023-neurips/lcdb/workflow/keras/_swa.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/_swa.py
@@ -1,0 +1,297 @@
+from keras.callbacks import Callback
+import keras.backend as K
+from keras.layers import BatchNormalization
+
+
+class SWA(Callback):
+    """Stochastic Weight Averging.
+
+    # Paper
+        title: Averaging Weights Leads to Wider Optima and Better Generalization
+        link: https://arxiv.org/abs/1803.05407
+
+    # Arguments
+        start_epoch:   integer, epoch when swa should start.
+        lr_schedule:   string, type of learning rate schedule.
+        swa_lr:        float, learning rate for swa.
+        swa_lr2:       float, upper bound of cyclic learning rate.
+        swa_freq:      integer, length of learning rate cycle.
+        batch_size     integer, batch size (for batch norm with generator)
+        verbose:       integer, verbosity mode, 0 or 1.
+    """
+
+    def __init__(
+            self,
+            start_epoch,
+            lr_schedule="manual",
+            swa_lr="auto",
+            swa_lr2="auto",
+            swa_freq=1,
+            batch_size=None,
+            verbose=0,
+    ):
+
+        super().__init__()
+        self.start_epoch = start_epoch - 1
+        self.lr_schedule = lr_schedule
+        self.swa_lr = swa_lr
+
+        # if no user determined upper bound, make one based off of the lower bound
+        self.swa_lr2 = swa_lr2 if swa_lr2 is not None else 10 * swa_lr
+        self.swa_freq = swa_freq
+        self.batch_size = batch_size
+        self.verbose = verbose
+
+        if start_epoch < 2:
+            raise ValueError('"swa_start" attribute cannot be lower than 2.')
+
+        schedules = ["manual", "constant", "cyclic"]
+
+        if self.lr_schedule not in schedules:
+            raise ValueError(
+                '"{}" is not a valid learning rate schedule'.format(
+                    self.lr_schedule
+                )
+            )
+
+        if self.lr_schedule == "cyclic" and self.swa_freq < 2:
+            raise ValueError(
+                '"swa_freq" must be higher than 1 for cyclic schedule.'
+            )
+
+        if self.swa_lr == "auto" and self.swa_lr2 != "auto":
+            raise ValueError(
+                '"swa_lr2" cannot be manually set if "swa_lr" is automatic.'
+            )
+
+        if (
+                self.lr_schedule == "cyclic"
+                and self.swa_lr != "auto"
+                and self.swa_lr2 != "auto"
+                and self.swa_lr > self.swa_lr2
+        ):
+            raise ValueError('"swa_lr" must be lower than "swa_lr2".')
+
+    def on_train_begin(self, logs=None):
+
+        self.lr_record = []
+        self.epochs = self.params.get("epochs")
+
+        if self.start_epoch >= self.epochs - 1:
+            raise ValueError('"swa_start" attribute must be lower than "epochs".')
+
+        self.init_lr = self.model.optimizer.learning_rate
+
+        # automatic swa_lr
+        if self.swa_lr == "auto":
+            self.swa_lr = 0.1 * self.init_lr
+
+        if self.init_lr < self.swa_lr:
+            raise ValueError('"swa_lr" must be lower than rate set in optimizer.')
+
+        # automatic swa_lr2 between initial lr and swa_lr
+        if self.lr_schedule == "cyclic" and self.swa_lr2 == "auto":
+            self.swa_lr2 = self.swa_lr + (self.init_lr - self.swa_lr) * 0.25
+
+        self._check_batch_norm()
+
+        if self.has_batch_norm and self.batch_size is None:
+            raise ValueError(
+                '"batch_size" needs to be set for models with batch normalization layers.'
+            )
+
+    def on_epoch_begin(self, epoch, logs=None):
+
+        self.current_epoch = epoch
+        self._scheduler(epoch)
+
+        # constant schedule is updated epoch-wise
+        if self.lr_schedule == "constant":
+            self._update_lr(epoch)
+
+        if self.is_swa_start_epoch:
+            self.swa_weights = self.model.get_weights()
+
+            if self.verbose > 0:
+                print(
+                    "\nEpoch %05d: starting stochastic weight averaging"
+                    % (epoch + 1)
+                )
+
+        if self.is_batch_norm_epoch:
+            self._set_swa_weights(epoch)
+
+            if self.verbose > 0:
+                print(
+                    "\nEpoch %05d: reinitializing batch normalization layers"
+                    % (epoch + 1)
+                )
+
+            self._reset_batch_norm()
+
+            if self.verbose > 0:
+                print(
+                    "\nEpoch %05d: running forward pass to adjust batch normalization"
+                    % (epoch + 1)
+                )
+
+    def on_batch_begin(self, batch, logs=None):
+
+        # update lr each batch for cyclic lr schedule
+        if self.lr_schedule == "cyclic":
+            self._update_lr(self.current_epoch, batch)
+
+        if self.is_batch_norm_epoch:
+
+            batch_size = self.batch_size
+            momentum = batch_size / (batch * batch_size + batch_size)
+
+            for layer in self.batch_norm_layers:
+                layer.momentum = momentum
+
+    def on_epoch_end(self, epoch, logs=None):
+
+        if self.is_swa_start_epoch:
+            self.swa_start_epoch = epoch
+
+        if self.is_swa_epoch and not self.is_batch_norm_epoch:
+            self.swa_weights = self._average_weights(epoch)
+
+    def on_train_end(self, logs=None):
+
+        if not self.has_batch_norm:
+            self._set_swa_weights(self.epochs)
+        else:
+            self._restore_batch_norm()
+
+        for batch_lr in self.lr_record:
+            self.model.history.history.setdefault("lr", []).append(batch_lr)
+
+    def _scheduler(self, epoch):
+
+        swa_epoch = epoch - self.start_epoch
+
+        self.is_swa_epoch = (
+                epoch >= self.start_epoch and swa_epoch % self.swa_freq == 0
+        )
+        self.is_swa_start_epoch = epoch == self.start_epoch
+        self.is_batch_norm_epoch = epoch == self.epochs - 1 and self.has_batch_norm
+
+    def _average_weights(self, epoch):
+
+        return [
+            (swa_w * ((epoch - self.start_epoch) / self.swa_freq) + w)
+            / ((epoch - self.start_epoch) / self.swa_freq + 1)
+            for swa_w, w in zip(self.swa_weights, self.model.get_weights())
+        ]
+
+    def _update_lr(self, epoch, batch=None):
+
+        if self.is_batch_norm_epoch:
+            lr = 0
+            K.set_value(self.model.optimizer.lr, lr)
+        elif self.lr_schedule == "constant":
+            lr = self._constant_schedule(epoch)
+            K.set_value(self.model.optimizer.lr, lr)
+        elif self.lr_schedule == "cyclic":
+            lr = self._cyclic_schedule(epoch, batch)
+            K.set_value(self.model.optimizer.lr, lr)
+        self.lr_record.append(lr)
+
+    def _constant_schedule(self, epoch):
+
+        t = epoch / self.start_epoch
+        lr_ratio = self.swa_lr / self.init_lr
+        if t <= 0.5:
+            factor = 1.0
+        elif t <= 0.9:
+            factor = 1.0 - (1.0 - lr_ratio) * (t - 0.5) / 0.4
+        else:
+            factor = lr_ratio
+        return self.init_lr * factor
+
+    def _cyclic_schedule(self, epoch, batch):
+        """Designed after Section 3.1 of Averaging Weights Leads to
+        Wider Optima and Better Generalization(https://arxiv.org/abs/1803.05407)
+        """
+        # steps are mini-batches per epoch, equal to training_samples / batch_size
+        steps = self.params.get("steps")
+
+        # occasionally steps parameter will not be set. We then calculate it ourselves
+        if steps is None:
+            steps = self.params["samples"] // self.params["batch_size"]
+
+        swa_epoch = (epoch - self.start_epoch) % self.swa_freq
+        cycle_length = self.swa_freq * steps
+
+        # batch 0 indexed, so need to add 1
+        i = (swa_epoch * steps) + (batch + 1)
+        if epoch >= self.start_epoch:
+
+            t = (((i - 1) % cycle_length) + 1) / cycle_length
+            return (1 - t) * self.swa_lr2 + t * self.swa_lr
+        else:
+            return self._constant_schedule(epoch)
+
+    def _set_swa_weights(self, epoch):
+
+        self.model.set_weights(self.swa_weights)
+
+        if self.verbose > 0:
+            print(
+                "\nEpoch %05d: final model weights set to stochastic weight average"
+                % (epoch + 1)
+            )
+
+    def _check_batch_norm(self):
+
+        self.batch_norm_momentums = []
+        self.batch_norm_layers = []
+        self.has_batch_norm = False
+        self.running_bn_epoch = False
+
+        for layer in self.model.layers:
+            if issubclass(layer.__class__, BatchNormalization):
+                self.has_batch_norm = True
+                self.batch_norm_momentums.append(layer.momentum)
+                self.batch_norm_layers.append(layer)
+
+        if self.verbose > 0 and self.has_batch_norm:
+            print(
+                "Model uses batch normalization. SWA will require last epoch "
+                "to be a forward pass and will run with no learning rate"
+            )
+
+    def _reset_batch_norm(self):
+
+        for layer in self.batch_norm_layers:
+
+            # to get properly initialized moving mean and moving variance weights
+            # we initialize a new batch norm layer from the config of the existing
+            # layer, build that layer, retrieve its reinitialized moving mean and
+            # moving var weights and then delete the layer
+            bn_config = layer.get_config()
+            new_batch_norm = BatchNormalization(**bn_config)
+            new_batch_norm.build(layer.input_shape)
+            new_moving_mean, new_moving_var = new_batch_norm.get_weights()[-2:]
+            # get rid of the new_batch_norm layer
+            del new_batch_norm
+            # get the trained gamma and beta from the current batch norm layer
+            trained_weights = layer.get_weights()
+            new_weights = []
+            # get gamma if exists
+            if bn_config["scale"]:
+                new_weights.append(trained_weights.pop(0))
+            # get beta if exists
+            if bn_config["center"]:
+                new_weights.append(trained_weights.pop(0))
+            new_weights += [new_moving_mean, new_moving_var]
+            # set weights to trained gamma and beta, reinitialized mean and variance
+            layer.set_weights(new_weights)
+
+    def _restore_batch_norm(self):
+
+        for layer, momentum in zip(
+                self.batch_norm_layers, self.batch_norm_momentums
+        ):
+            layer.momentum = momentum

--- a/publications/2023-neurips/lcdb/workflow/keras/utils.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/utils.py
@@ -2,6 +2,7 @@ import platform
 
 import keras
 import numpy as np
+import importlib
 
 
 def is_arm_mac():
@@ -89,3 +90,27 @@ def count_params(model: keras.Model) -> dict:
         "num_parameters_not_train": num_parameters_not_train,
         "num_parameters_train": num_parameters_train,
     }
+
+
+def serialize_object(obj):
+    config = obj.get_config()
+    class_name = obj.__class__.__name__
+    module_name = obj.__class__.__module__
+    return {
+        'class_name': class_name,
+        'module_name': module_name,
+        'config': config
+    }
+
+
+def deserialize_object(serialized_obj):
+    class_name = serialized_obj['class_name']
+    module_name = serialized_obj['module_name']
+    config = serialized_obj['config']
+
+    # Dynamically import the module and get the class
+    module = importlib.import_module(module_name)
+    cls = getattr(module, class_name)
+
+    # Use the class to create a new instance
+    return cls.from_config(config)

--- a/publications/2023-neurips/lcdb/workflow/keras/utils.py
+++ b/publications/2023-neurips/lcdb/workflow/keras/utils.py
@@ -1,8 +1,8 @@
 import platform
+import importlib
 
 import keras
 import numpy as np
-import importlib
 
 
 def is_arm_mac():

--- a/publications/2023-neurips/lcdb/workflow/sklearn/_liblinear.py
+++ b/publications/2023-neurips/lcdb/workflow/sklearn/_liblinear.py
@@ -109,10 +109,8 @@ class LibLinearWorkflow(PreprocessedWorkflow):
     def config_space(cls):
         return cls._config_space
 
-    def _fit(self, X, y, metadata):
+    def _fit_model_after_transformation(self, X, y, X_valid, y_valid, X_test, y_test, metadata):
         self.metadata = metadata
-        X = self.transform(X, y, metadata)
-
         self.learner.fit(X, y)
 
         self.infos["classes"] = list(self.learner.classes_)
@@ -124,12 +122,10 @@ class LibLinearWorkflow(PreprocessedWorkflow):
                 n_iter_.append(est.n_iter_)
             self.infos["n_iter_"] = n_iter_
 
-    def _predict(self, X):
-        X = self.pp_pipeline.transform(X)
+    def _predict_after_transform(self, X):
         return self.learner.predict(X)
 
-    def _predict_proba(self, X):
-        X = self.pp_pipeline.transform(X)
+    def _predict_proba_after_transform(self, X):
         decision_fun_vals = self.learner.decision_function(X)
         sigmoid = lambda z: 1/(1 + np.exp(-z))
         if len(decision_fun_vals.shape) == 2:

--- a/publications/2023-neurips/lcdb/workflow/sklearn/_majority.py
+++ b/publications/2023-neurips/lcdb/workflow/sklearn/_majority.py
@@ -15,8 +15,8 @@ class MajorityWorkflow(BaseWorkflow):
     # Static Attribute
     _config_space = CONFIG_SPACE
 
-    def __init__(self, timer=None, random_state=None):
-        super().__init__(timer)
+    def __init__(self, timer=None, random_state=None, **kwargs):
+        super().__init__(timer, **kwargs)
 
         self.learner = DummyClassifier(strategy="prior", random_state=random_state)
 
@@ -24,7 +24,7 @@ class MajorityWorkflow(BaseWorkflow):
     def config_space(cls):
         return cls._config_space
 
-    def _fit(self, X, y, metadata):
+    def _fit(self, X, y, X_valid, y_valid, X_test, y_test, metadata):
         self.metadata = metadata
 
         self.learner.fit(X, y)

--- a/publications/2023-neurips/lcdb/workflow/sklearn/_majority_with_pp.py
+++ b/publications/2023-neurips/lcdb/workflow/sklearn/_majority_with_pp.py
@@ -24,7 +24,7 @@ class MajorityWorkflowWithPreprocessing(PreprocessedWorkflow):
     def config_space(cls):
         return cls._config_space
 
-    def _fit(self, X, y, metadata):
+    def _fit_model_after_transformation(self, X, y, X_valid, y_valid, X_test, y_test, metadata):
         self.metadata = metadata
 
         X = self.transform(X, y, metadata)


### PR DESCRIPTION
- Regularization Techniques for NNs:
    - SWA
    - Lookahead
    - Snapshot Ensembles
- unified application of data transformation in the PreprocessingWorkflow
- not label-encoding the y anymore at the data loading level but only inside of the workflows, so that for later analysis we still have the original labels available when compiling the confusion matrix automatically create constant predictions (independently of the concrete workflow) if the training data has only one class
- resolved issues in the AUCROC metric when there is only one class available
- fixed bugs in LibSVM and also added proper support for the pre-processing
- fixed bugs in the OOB iteration learning curve of RandomForestWorkflow
- introduced epoch-schedule for XGBoost
- resolved bug in the internal labeling of the neural network workflow
- removed unnecessary complicated invocation logic with optional X_valid, X_test etc. this is now always transmitted, and workflows can just ignore them if they don't want to use them.- 